### PR TITLE
fixing NullPointerException in JettyConfiguration on startup

### DIFF
--- a/src/main/resources/jetty.yaml
+++ b/src/main/resources/jetty.yaml
@@ -5,8 +5,6 @@
 
 max-threads: 500
 
-cors-url: http://localhost:9000
-
 context:
     descriptor: src/main/webapp/WEB-INF/web.xml
     resource-base: src/main/webapp
@@ -41,7 +39,7 @@ truststore:
     path: security/rhizome.jks
     password: rhizome
 
-gzip: 
+gzip:
     enabled: true
 
 security-enabled: true


### PR DESCRIPTION
@geekbeast It looks like `cors-url: http://localhost:9000` might have been committed by mistake? `JettyConfiguration` doesn't do anything with `cors-url`, or anything else.