### PR TITLE
Bugfix/backend 837

### DIFF
--- a/src/main/java/com/dataloom/datastore/linking/services/SimpleElasticSearchBlocker.java
+++ b/src/main/java/com/dataloom/datastore/linking/services/SimpleElasticSearchBlocker.java
@@ -31,7 +31,6 @@ public class SimpleElasticSearchBlocker implements Blocker {
     private final CassandraDataManager dataManager;
     private SearchService              searchService;
 
-    private Map<UUID, UUID>            entitySetsWithSyncIds;
     private SetMultimap<UUID, UUID>    linkIndexedByEntitySets;
     private Set<UUID>                  linkingES;
 
@@ -51,12 +50,11 @@ public class SimpleElasticSearchBlocker implements Blocker {
 
     @Override
     public void setLinking(
-            Map<UUID, UUID> entitySetsWithSyncIds,
+            Set<UUID> linkingEntitySets,
             SetMultimap<UUID, UUID> linkIndexedByPropertyTypes,
             SetMultimap<UUID, UUID> linkIndexedByEntitySets ) {
-        this.entitySetsWithSyncIds = entitySetsWithSyncIds;
         this.linkIndexedByEntitySets = linkIndexedByEntitySets;
-        this.linkingES = new HashSet<>( entitySetsWithSyncIds.keySet() );
+        this.linkingES = new HashSet<>( linkingEntitySets );
     }
 
     @Override
@@ -72,8 +70,7 @@ public class SimpleElasticSearchBlocker implements Blocker {
         Set<UUID> propertiesSet = ImmutableSet.copyOf( linkIndexedByEntitySets.get( entitySetId ) );
         Map<UUID, PropertyType> propertiesMap = propertiesSet.stream()
                 .collect( Collectors.toMap( ptId -> ptId, ptId -> dms.getPropertyType( ptId ) ) );
-        Set<UUID> syncIds = ImmutableSet.of( entitySetsWithSyncIds.get( entitySetId ) );
-        Iterable<String> entityIds = dataManager.getEntityIds( entitySetId, syncIds );
+        Iterable<String> entityIds = dataManager.getEntityIds( entitySetId );
 
         Stream<EntityKey> entityKeys = StreamUtil.stream( entityIds )
                 .map( entityId -> new EntityKey( entitySetId, entityId ) );

--- a/src/main/java/com/dataloom/datastore/linking/services/SimpleElasticSearchBlocker.java
+++ b/src/main/java/com/dataloom/datastore/linking/services/SimpleElasticSearchBlocker.java
@@ -76,7 +76,7 @@ public class SimpleElasticSearchBlocker implements Blocker {
                 .map( entityId -> new EntityKey( entitySetId, entityId ) );
 
         Stream<Pair<EntityKey, SetMultimap<UUID, Object>>> entityKeyDataPairs = entityKeys
-                .map( key -> Pair.of( key, dataManager.asyncLoadEntity( key.getEntityId(), propertiesSet ) ) )
+                .map( key -> Pair.of( key, dataManager.asyncLoadEntity( key.getEntitySetId(), key.getEntityId(), propertiesSet ) ) )
                 .map( rsfPair -> Pair.of( rsfPair.getKey(), rsfPair.getValue().getUninterruptibly() ) )
                 .map( rsPair -> Pair.of( rsPair.getKey(),
                         dataManager.rowToEntityIndexedById( rsPair.getValue(), propertiesMap ) ) );

--- a/src/main/java/com/dataloom/datastore/linking/services/SimpleMatcher.java
+++ b/src/main/java/com/dataloom/datastore/linking/services/SimpleMatcher.java
@@ -13,7 +13,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.dataloom.linking.Entity;
-import com.dataloom.linking.SortedCassandraLinkingEdgeBuffer;
 import com.dataloom.linking.components.Matcher;
 import com.dataloom.linking.util.UnorderedPair;
 import com.google.common.collect.ImmutableSet;
@@ -25,7 +24,7 @@ import com.kryptnostic.datastore.services.EdmManager;
  *
  */
 public class SimpleMatcher implements Matcher {
-    private static final Logger                              logger                  = LoggerFactory
+    private static final Logger     logger          = LoggerFactory
             .getLogger( SimpleMatcher.class );
 
     private SetMultimap<UUID, UUID> linkIndexedByPropertyTypes;
@@ -34,8 +33,8 @@ public class SimpleMatcher implements Matcher {
     private Map<UUID, Double>       weights;
 
     private static DoubleMetaphone  doubleMetaphone = new DoubleMetaphone();
-    
-    private static final double MAX_DISTANCE = Double.POSITIVE_INFINITY;
+
+    private static final double     MAX_DISTANCE    = Double.POSITIVE_INFINITY;
 
     private final EdmManager        dms;
 
@@ -63,7 +62,7 @@ public class SimpleMatcher implements Matcher {
                 Object val0 = elem0.getProperties().get( pidAsString );
                 Object val1 = elem1.getProperties().get( pidAsString );
                 if ( val0 != null && val1 != null ) {
-                    if( dist == MAX_DISTANCE ){
+                    if ( dist == MAX_DISTANCE ) {
                         dist = 0;
                     }
                     // Both values are non-null; score can be computed.
@@ -76,7 +75,7 @@ public class SimpleMatcher implements Matcher {
 
     @Override
     public void setLinking(
-            Map<UUID, UUID> entitySetsWithSyncIds,
+            Set<UUID> linkingEntitySets,
             SetMultimap<UUID, UUID> linkIndexedByPropertyTypes,
             SetMultimap<UUID, UUID> linkIndexedByEntitySets ) {
         this.linkIndexedByPropertyTypes = linkIndexedByPropertyTypes;
@@ -170,7 +169,7 @@ public class SimpleMatcher implements Matcher {
      * @return
      */
     private double getDistance( UUID propertyTypeId, String val0, String val1 ) {
-        if( val0 == null || val1 == null ){
+        if ( val0 == null || val1 == null ) {
             return MAX_DISTANCE;
         }
         switch ( getPropertyName( propertyTypeId ) ) {

--- a/src/main/java/com/dataloom/datastore/services/CassandraDataManager.java
+++ b/src/main/java/com/dataloom/datastore/services/CassandraDataManager.java
@@ -55,7 +55,6 @@ import com.datastax.driver.core.querybuilder.Select;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Iterables;
-import com.google.common.collect.Maps;
 import com.google.common.collect.SetMultimap;
 import com.google.common.eventbus.EventBus;
 import com.kryptnostic.conductor.rpc.odata.Table;
@@ -76,14 +75,14 @@ public class CassandraDataManager {
     private final ObjectMapper           mapper;
     private final HazelcastLinkingGraphs linkingGraph;
 
-    private final PreparedStatement      writeIdLookupQuery;
     private final PreparedStatement      writeDataQuery;
+
+    private final PreparedStatement      entitySetQueryUpToSyncId;
     private final PreparedStatement      entitySetQuery;
     private final PreparedStatement      entityIdsQuery;
 
     private final PreparedStatement      entityIdsLookupByEntitySetQuery;
     private final PreparedStatement      deleteEntityQuery;
-    private final PreparedStatement      deleteEntityLookupQuery;
 
     private final PreparedStatement      linkedEntitiesQuery;
 
@@ -94,17 +93,15 @@ public class CassandraDataManager {
         this.mapper = mapper;
         this.linkingGraph = linkingGraph;
 
-        CassandraTableBuilder idLookupTableDefinitions = Table.ENTITY_ID_LOOKUP.getBuilder();
         CassandraTableBuilder dataTableDefinitions = Table.DATA.getBuilder();
 
+        this.entitySetQueryUpToSyncId = prepareEntitySetQueryUpToSyncId( session, dataTableDefinitions );
         this.entitySetQuery = prepareEntitySetQuery( session, dataTableDefinitions );
         this.entityIdsQuery = prepareEntityIdsQuery( session );
-        this.writeIdLookupQuery = prepareWriteQuery( session, idLookupTableDefinitions );
         this.writeDataQuery = prepareWriteQuery( session, dataTableDefinitions );
 
         this.entityIdsLookupByEntitySetQuery = prepareEntityIdsLookupByEntitySetQuery( session );
         this.deleteEntityQuery = prepareDeleteEntityQuery( session );
-        this.deleteEntityLookupQuery = prepareDeleteEntityLookupQuery( session );
 
         this.linkedEntitiesQuery = prepareLinkedEntitiesQuery( session );
         this.readNumRPCRowsQuery = prepareReadNumRPCRowsQuery( session );
@@ -112,18 +109,18 @@ public class CassandraDataManager {
 
     public Iterable<SetMultimap<FullQualifiedName, Object>> getEntitySetData(
             UUID entitySetId,
-            Set<UUID> syncIds,
+            UUID syncId,
             Map<UUID, PropertyType> authorizedPropertyTypes ) {
-        Iterable<ResultSet> entityRows = getRows( entitySetId, syncIds, authorizedPropertyTypes.keySet() );
+        Iterable<ResultSet> entityRows = getRows( entitySetId, syncId, authorizedPropertyTypes.keySet() );
         return Iterables.transform( entityRows,
                 rs -> rowToEntity( rs, authorizedPropertyTypes ) )::iterator;
     }
 
     public Iterable<SetMultimap<UUID, Object>> getEntitySetDataIndexedById(
             UUID entitySetId,
-            Set<UUID> syncIds,
+            UUID syncId,
             Map<UUID, PropertyType> authorizedPropertyTypes ) {
-        Iterable<ResultSet> entityRows = getRows( entitySetId, syncIds, authorizedPropertyTypes.keySet() );
+        Iterable<ResultSet> entityRows = getRows( entitySetId, syncId, authorizedPropertyTypes.keySet() );
         return Iterables.transform( entityRows,
                 rs -> rowToEntityIndexedById( rs, authorizedPropertyTypes ) )::iterator;
     }
@@ -152,11 +149,11 @@ public class CassandraDataManager {
 
     private Iterable<ResultSet> getRows(
             UUID entitySetId,
-            Set<UUID> syncIds,
+            UUID syncId,
             Set<UUID> authorizedProperties ) {
-        Iterable<String> entityIds = getEntityIds( entitySetId, syncIds );
+        Iterable<String> entityIds = getEntityIds( entitySetId );
         Iterable<ResultSetFuture> entityFutures = Iterables.transform( entityIds,
-                entityId -> asyncLoadEntity( entityId, authorizedProperties ) );
+                entityId -> asyncLoadEntity( entityId, syncId, authorizedProperties ) );
         return Iterables.transform( entityFutures, ResultSetFuture::getUninterruptibly );
     }
 
@@ -170,9 +167,8 @@ public class CassandraDataManager {
         return RowAdapters.entity( rs, authorizedPropertyTypes, mapper );
     }
 
-    public Iterable<String> getEntityIds( UUID entitySetId, Set<UUID> syncIds ) {
+    public Iterable<String> getEntityIds( UUID entitySetId ) {
         BoundStatement boundEntityIdsQuery = entityIdsQuery.bind()
-                .setSet( CommonColumns.SYNCID.cql(), syncIds )
                 .setUUID( CommonColumns.ENTITY_SET_ID.cql(), entitySetId );
         ResultSet entityIds = session.execute( boundEntityIdsQuery );
         return Iterables.filter( Iterables.transform( entityIds, RowAdapters::entityId ), StringUtils::isNotBlank );
@@ -182,6 +178,13 @@ public class CassandraDataManager {
         return session.executeAsync( entitySetQuery.bind()
                 .setString( CommonColumns.ENTITYID.cql(), entityId )
                 .setSet( CommonColumns.PROPERTY_TYPE_ID.cql(), authorizedProperties ) );
+    }
+
+    public ResultSetFuture asyncLoadEntity( String entityId, UUID syncId, Set<UUID> authorizedProperties ) {
+        return session.executeAsync( entitySetQuery.bind()
+                .setString( CommonColumns.ENTITYID.cql(), entityId )
+                .setSet( CommonColumns.PROPERTY_TYPE_ID.cql(), authorizedProperties )
+                .setUUID( CommonColumns.SYNCID.cql(), syncId ) );
     }
 
     public void createEntityData(
@@ -194,11 +197,6 @@ public class CassandraDataManager {
         List<ResultSetFuture> results = new ArrayList<ResultSetFuture>();
 
         entities.entrySet().stream().forEach( entity -> {
-
-            results.add(
-                    session.executeAsync( writeIdLookupQuery.bind().setUUID( CommonColumns.SYNCID.cql(), syncId )
-                            .setUUID( CommonColumns.ENTITY_SET_ID.cql(), entitySetId )
-                            .setString( CommonColumns.ENTITYID.cql(), entity.getKey() ) ) );
 
             SetMultimap<UUID, Object> propertyValues = entity.getValue();
 
@@ -223,6 +221,7 @@ public class CassandraDataManager {
                     .forEach( entry -> {
                         results.add( session.executeAsync(
                                 writeDataQuery.bind()
+                                        .setUUID( CommonColumns.ENTITY_SET_ID.cql(), entitySetId )
                                         .setString( CommonColumns.ENTITYID.cql(), entity.getKey() )
                                         .setUUID( CommonColumns.SYNCID.cql(), syncId )
                                         .setUUID( CommonColumns.PROPERTY_TYPE_ID.cql(), entry.getKey() )
@@ -282,8 +281,7 @@ public class CassandraDataManager {
             UUID syncId = RowAdapters.syncId( entityIdRow );
             String entityId = RowAdapters.entityId( entityIdRow );
 
-            results.add( asyncDeleteEntity( entityId ) );
-            results.add( asyncDeleteEntityLookup( syncId, entitySetId, entityId ) );
+            results.add( asyncDeleteEntity( entitySetId, entityId ) );
 
             counter++;
         }
@@ -292,14 +290,8 @@ public class CassandraDataManager {
         logger.info( "Finish deletion of entity set data: {}", entitySetId );
     }
 
-    public ResultSetFuture asyncDeleteEntity( String entityId ) {
+    public ResultSetFuture asyncDeleteEntity( UUID entitySetId, String entityId ) {
         return session.executeAsync( deleteEntityQuery.bind()
-                .setString( CommonColumns.ENTITYID.cql(), entityId ) );
-    }
-
-    public ResultSetFuture asyncDeleteEntityLookup( UUID syncId, UUID entitySetId, String entityId ) {
-        return session.executeAsync( deleteEntityLookupQuery.bind()
-                .setUUID( CommonColumns.SYNCID.cql(), syncId )
                 .setUUID( CommonColumns.ENTITY_SET_ID.cql(), entitySetId )
                 .setString( CommonColumns.ENTITYID.cql(), entityId ) );
     }
@@ -308,6 +300,12 @@ public class CassandraDataManager {
             Session session,
             CassandraTableBuilder ctb ) {
         return session.prepare( entitySetQuery( ctb ) );
+    }
+
+    private static PreparedStatement prepareEntitySetQueryUpToSyncId(
+            Session session,
+            CassandraTableBuilder ctb ) {
+        return session.prepare( entitySetQueryUpToSyncId( ctb ) );
     }
 
     private static PreparedStatement prepareWriteQuery(
@@ -327,12 +325,19 @@ public class CassandraDataManager {
                         CommonColumns.PROPERTY_TYPE_ID.bindMarker() ) );
     }
 
+    private static Select.Where entitySetQueryUpToSyncId( CassandraTableBuilder ctb ) {
+        return ctb.buildLoadAllQuery().where( QueryBuilder
+                .eq( CommonColumns.ENTITYID.cql(), CommonColumns.ENTITYID.bindMarker() ) )
+                .and( QueryBuilder.in( CommonColumns.PROPERTY_TYPE_ID.cql(),
+                        CommonColumns.PROPERTY_TYPE_ID.bindMarker() ) )
+                .and( QueryBuilder.lt( CommonColumns.SYNCID.cql(), CommonColumns.SYNCID.bindMarker() ) );
+    }
+
     private static PreparedStatement prepareEntityIdsQuery( Session session ) {
         return session.prepare( QueryBuilder
-                .select( CommonColumns.ENTITYID.cql() )
-                .from( Table.ENTITY_ID_LOOKUP.getKeyspace(), Table.ENTITY_ID_LOOKUP.getName() )
-                .where( QueryBuilder.eq( CommonColumns.ENTITY_SET_ID.cql(), QueryBuilder.bindMarker() ) )
-                .and( QueryBuilder.in( CommonColumns.SYNCID.cql(), CommonColumns.SYNCID.bindMarker() ) ) );
+                .select().distinct()
+                .from( Table.DATA.getKeyspace(), Table.DATA.getName() )
+                .where( QueryBuilder.eq( CommonColumns.ENTITY_SET_ID.cql(), QueryBuilder.bindMarker() ) ) );
     }
 
     private static PreparedStatement prepareLinkedEntitiesQuery( Session session ) {
@@ -346,7 +351,7 @@ public class CassandraDataManager {
             Session session ) {
         return session.prepare( QueryBuilder
                 .select()
-                .from( Table.ENTITY_ID_LOOKUP.getKeyspace(), Table.ENTITY_ID_LOOKUP.getName() )
+                .from( Table.DATA.getKeyspace(), Table.DATA.getName() )
                 .where( QueryBuilder.eq( CommonColumns.ENTITY_SET_ID.cql(), QueryBuilder.bindMarker() ) ) );
     }
 
@@ -361,16 +366,6 @@ public class CassandraDataManager {
     private static PreparedStatement prepareDeleteEntityQuery(
             Session session ) {
         return session.prepare( Table.DATA.getBuilder().buildDeleteByPartitionKeyQuery() );
-    }
-
-    private static PreparedStatement prepareDeleteEntityLookupQuery(
-            Session session ) {
-        return session.prepare( QueryBuilder
-                .delete()
-                .from( Table.ENTITY_ID_LOOKUP.getKeyspace(), Table.ENTITY_ID_LOOKUP.getName() )
-                .where( QueryBuilder.eq( CommonColumns.SYNCID.cql(), QueryBuilder.bindMarker() ) )
-                .and( QueryBuilder.eq( CommonColumns.ENTITY_SET_ID.cql(), QueryBuilder.bindMarker() ) )
-                .and( QueryBuilder.eq( CommonColumns.ENTITYID.cql(), QueryBuilder.bindMarker() ) ) );
     }
 
     /**

--- a/src/test/java/com/dataloom/datastore/data/DataControllerTest.java
+++ b/src/test/java/com/dataloom/datastore/data/DataControllerTest.java
@@ -79,7 +79,7 @@ public class DataControllerTest extends MultipleAuthenticatedUsersBase {
         Set<UUID> selectedProperties = et.getProperties().stream().filter( pid -> random.nextBoolean() )
                 .collect( Collectors.toSet() );
         EntitySetSelection ess = new EntitySetSelection(
-                Optional.of( ImmutableSet.of( syncId ) ),
+                Optional.of( syncId ),
                 Optional.of( selectedProperties ) );
         Iterable<SetMultimap<FullQualifiedName, Object>> results = dataApi.loadEntitySetData( es.getId(), ess, null );
 

--- a/src/test/java/com/dataloom/datastore/data/DataControllerTest.java
+++ b/src/test/java/com/dataloom/datastore/data/DataControllerTest.java
@@ -37,6 +37,7 @@ import com.dataloom.datastore.authentication.MultipleAuthenticatedUsersBase;
 import com.dataloom.edm.EntitySet;
 import com.dataloom.edm.type.EntityType;
 import com.dataloom.mapstores.TestDataFactory;
+import com.datastax.driver.core.utils.UUIDs;
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
@@ -45,7 +46,7 @@ import com.google.common.collect.SetMultimap;
 public class DataControllerTest extends MultipleAuthenticatedUsersBase {
 
     private static final int    numberOfEntries = 10;
-    private static final UUID   syncId          = Syncs.BASE.getSyncId();
+    private static final UUID   syncId          = UUIDs.timeBased();
     private static final Random random          = new Random();
 
     @BeforeClass

--- a/src/test/java/com/dataloom/datastore/data/DataManagerTest.java
+++ b/src/test/java/com/dataloom/datastore/data/DataManagerTest.java
@@ -52,6 +52,7 @@ import org.junit.Test;
 
 import com.dataloom.datastore.BootstrapDatastoreWithCassandra;
 import com.dataloom.edm.type.PropertyType;
+import com.datastax.driver.core.utils.UUIDs;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Optional;
 import com.google.common.collect.HashMultimap;
@@ -112,7 +113,7 @@ public class DataManagerTest extends BootstrapDatastoreWithCassandra {
         Map<String, SetMultimap<UUID, Object>> entities = generateData( 10, propertiesWithDataType, 1 );
 
         testWriteData( entitySetId, syncId, entities, propertiesWithDataType );
-        Set<SetMultimap<FullQualifiedName, Object>> result = testReadData( ImmutableSet.of( syncId ),
+        Set<SetMultimap<FullQualifiedName, Object>> result = testReadData( syncId,
                 entitySetId,
                 propertyTypes );
 
@@ -127,8 +128,8 @@ public class DataManagerTest extends BootstrapDatastoreWithCassandra {
     @Test
     public void testWriteAndDelete() {
         final UUID entitySetId = UUID.randomUUID();
-        final UUID firstSyncId = UUID.randomUUID();
-        final UUID secondSyncId = UUID.randomUUID();
+        final UUID firstSyncId = UUIDs.timeBased();
+        final UUID secondSyncId = UUIDs.timeBased();
 
         Map<UUID, PropertyType> propertyTypes = generateProperties( 5 );
         Map<UUID, EdmPrimitiveTypeKind> propertiesWithDataType = propertyTypes.entrySet().stream()
@@ -142,7 +143,7 @@ public class DataManagerTest extends BootstrapDatastoreWithCassandra {
 
         dataService.deleteEntitySetData( entitySetId );
         
-        Assert.assertEquals( 0, testReadData( ImmutableSet.of( firstSyncId, secondSyncId ),
+        Assert.assertEquals( 0, testReadData( secondSyncId,
                 entitySetId,
                 propertyTypes ).size() );
     }
@@ -200,10 +201,10 @@ public class DataManagerTest extends BootstrapDatastoreWithCassandra {
     }
 
     public Set<SetMultimap<FullQualifiedName, Object>> testReadData(
-            Set<UUID> syncIds,
+            UUID syncId,
             UUID entitySetId,
             Map<UUID, PropertyType> propertyTypes ) {
-        return Sets.newHashSet( dataService.getEntitySetData( entitySetId, syncIds, propertyTypes ) );
+        return Sets.newHashSet( dataService.getEntitySetData( entitySetId, syncId, propertyTypes ) );
     }
 
     private Map<UUID, PropertyType> generateProperties( int n ) {

--- a/src/test/java/com/dataloom/datastore/data/DataManagerTest.java
+++ b/src/test/java/com/dataloom/datastore/data/DataManagerTest.java
@@ -105,7 +105,7 @@ public class DataManagerTest extends BootstrapDatastoreWithCassandra {
     @Test
     public void testWriteAndRead() {
         final UUID entitySetId = UUID.randomUUID();
-        final UUID syncId = UUID.randomUUID();
+        final UUID syncId = UUIDs.timeBased();
 
         Map<UUID, PropertyType> propertyTypes = generateProperties( 5 );
         Map<UUID, EdmPrimitiveTypeKind> propertiesWithDataType = propertyTypes.entrySet().stream()
@@ -124,6 +124,7 @@ public class DataManagerTest extends BootstrapDatastoreWithCassandra {
         
         Assert.assertEquals( convertValueToString( expected, propertiesWithDataTypeIndexedByFqn, this::getStringFromRaw ), convertValueToString( result, propertiesWithDataTypeIndexedByFqn, this::getStringFromNormalized ) );
     }
+    
     
     @Test
     public void testWriteAndDelete() {
@@ -150,7 +151,7 @@ public class DataManagerTest extends BootstrapDatastoreWithCassandra {
 
     @Ignore
     public void populateEmployeeCsv() throws FileNotFoundException, IOException {
-        final UUID syncId = UUID.randomUUID();
+        final UUID syncId = UUIDs.timeBased();
         final UUID entitySetId = UUID.randomUUID();
         // Four property types: Employee Name, Title, Department, Salary
         Map<String, UUID> idLookup = getUUIDsForEmployeeCsvProperties();


### PR DESCRIPTION
Refactor DataManager
- remove `entity_id_lookup` table; add `entity_set_id` column (as part of partition key) to data table.
- refactoring `syncId`: 
  a.`syncId` is now a `timeuuid`
  b. Snapshot of a (historical) data set was specified by `Set<UUID>` in the past (this represents data in several syncId's, which were previously plain UUIDs). This is now changed to a single `UUID`, and retrieving a snapshot would mean "retrieving entities recorded before the specified sync". (now possible, since we now use timeuuid)