### PR TITLE
EntitySetData should have properties ordered

### DIFF
--- a/src/main/java/com/dataloom/datastore/analysis/controllers/AnalysisController.java
+++ b/src/main/java/com/dataloom/datastore/analysis/controllers/AnalysisController.java
@@ -1,6 +1,7 @@
 package com.dataloom.datastore.analysis.controllers;
 
 import java.util.EnumSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -84,8 +85,9 @@ public class AnalysisController implements AnalysisApi {
                 numResults,
                 topUtilizerDetails,
                 authorizedPropertyTypes );
-        Set<Object> columnTitles = authorizedPropertyTypes.values().stream().map( pt -> pt.getType() )
-                .collect( Collectors.toSet() );
+        LinkedHashSet<String> columnTitles = authorizedPropertyTypes.values().stream().map( pt -> pt.getType() )
+                .map( fqn -> fqn.toString() )
+                .collect( Collectors.toCollection( () -> new LinkedHashSet<String>() ) );
         columnTitles.add( "count" );
         columnTitles.add( "id" );
         return new EntitySetData<Object>( columnTitles, utilizers );

--- a/src/main/java/com/dataloom/datastore/converters/CsvHttpMessageConverter.java
+++ b/src/main/java/com/dataloom/datastore/converters/CsvHttpMessageConverter.java
@@ -54,7 +54,7 @@ public class CsvHttpMessageConverter
     }
 
     @Override
-    public EntitySetData read(
+    public EntitySetData<?> read(
             Type type,
             Class<?> contextClass,
             HttpInputMessage inputMessage )
@@ -80,17 +80,17 @@ public class CsvHttpMessageConverter
     }
 
     @Override
-    protected EntitySetData readInternal(
+    protected EntitySetData<?> readInternal(
             Class<? extends EntitySetData> clazz,
             HttpInputMessage inputMessage ) throws IOException, HttpMessageNotReadableException {
         throw new UnsupportedOperationException( "CSV is not a supported input format" );
     }
 
-    public CsvSchema schemaBuilder( EntitySetData t ) {
+    public CsvSchema schemaBuilder( EntitySetData<?> t ) {
         Builder schemaBuilder = CsvSchema.builder();
 
-        for ( FullQualifiedName type : t.getAuthorizedPropertyFqns() ) {
-            schemaBuilder.addColumn( type.toString(), ColumnType.ARRAY );
+        for ( String title : t.getColumnTitles() ) {
+            schemaBuilder.addColumn( title, ColumnType.ARRAY );
         }
         return schemaBuilder.setUseHeader( true ).build();
     }

--- a/src/main/java/com/dataloom/datastore/data/controllers/DataController.java
+++ b/src/main/java/com/dataloom/datastore/data/controllers/DataController.java
@@ -70,6 +70,7 @@ import com.dataloom.data.EntitySetData;
 import com.dataloom.data.requests.Association;
 import com.dataloom.data.requests.BulkDataCreation;
 import com.dataloom.data.requests.EntitySetSelection;
+import com.dataloom.data.requests.FileType;
 import com.dataloom.datastore.constants.CustomMediaType;
 import com.dataloom.datastore.services.SyncTicketService;
 import com.dataloom.edm.processors.EdmPrimitiveTypeKindGetter;

--- a/src/main/java/com/dataloom/datastore/data/controllers/DataController.java
+++ b/src/main/java/com/dataloom/datastore/data/controllers/DataController.java
@@ -237,14 +237,15 @@ public class DataController implements DataApi, AuthorizingComponent {
                     EnumSet.of( Permission.READ ) );
         }
 
-        LinkedHashSet<FullQualifiedName> orderedPropertyFqns = authzHelper.getAllPropertiesOnEntitySet( entitySetId )
+        LinkedHashSet<String> orderedPropertyNames = authzHelper.getAllPropertiesOnEntitySet( entitySetId )
                 .stream()
                 .filter( authorizedProperties::contains )
                 .map( ptId -> dms.getPropertyType( ptId ).getType() )
+                .map( fqn -> fqn.toString() )
                 .collect( Collectors.toCollection( () -> new LinkedHashSet<>() ) );
         Map<UUID, PropertyType> authorizedPropertyTypes = authorizedProperties.stream()
                 .collect( Collectors.toMap( ptId -> ptId, ptId -> dms.getPropertyType( ptId ) ) );
-        return dgm.getEntitySetData( entitySetId, id, orderedPropertyFqns, authorizedPropertyTypes );
+        return dgm.getEntitySetData( entitySetId, id, orderedPropertyNames, authorizedPropertyTypes );
     }
 
     private EntitySetData loadLinkedEntitySetData(
@@ -257,8 +258,9 @@ public class DataController implements DataApi, AuthorizingComponent {
                         } )
                 .collect( Collectors.toCollection( () -> new LinkedHashSet<>() ) );
 
-        LinkedHashSet<FullQualifiedName> orderedPropertyFqns = authorizedPropertiesOfEntityType
+        LinkedHashSet<String> orderedPropertyFqns = authorizedPropertiesOfEntityType
                 .stream().map( ptId -> dms.getPropertyType( ptId ).getType() )
+                .map( fqn -> fqn.toString() )
                 .collect( Collectors.toCollection( () -> new LinkedHashSet<>() ) );
         
         Map<UUID, Map<UUID, PropertyType>> authorizedPropertyTypesForEntitySets = new HashMap<>();

--- a/src/main/java/com/dataloom/datastore/edm/controllers/EdmController.java
+++ b/src/main/java/com/dataloom/datastore/edm/controllers/EdmController.java
@@ -57,6 +57,7 @@ import com.dataloom.authorization.Principals;
 import com.dataloom.authorization.securable.SecurableObjectType;
 import com.dataloom.authorization.util.AuthorizationUtils;
 import com.dataloom.data.DatasourceManager;
+import com.dataloom.data.requests.FileType;
 import com.dataloom.data.storage.CassandraEntityDatastore;
 import com.dataloom.datastore.constants.CustomMediaType;
 import com.dataloom.edm.EdmApi;
@@ -543,7 +544,7 @@ public class EdmController implements EdmApi, AuthorizingComponent {
     public Iterable<EntityType> getEntityTypes() {
         return modelService.getEntityTypes()::iterator;
     }
-    
+
     @Override
     @RequestMapping(
         path = ASSOCIATION_TYPE_PATH,

--- a/src/main/java/com/dataloom/datastore/services/LinkingService.java
+++ b/src/main/java/com/dataloom/datastore/services/LinkingService.java
@@ -132,10 +132,11 @@ public class LinkingService {
     }
 
     private void mergeEntities( UUID linkedEntitySetId, Set<UUID> ownablePropertyTypes ) {
-        LinkedHashSet<FullQualifiedName> orderedPropertyFqns = dms.getEntityTypeByEntitySetId( linkedEntitySetId )
+        LinkedHashSet<String> orderedPropertyNames = dms.getEntityTypeByEntitySetId( linkedEntitySetId )
                 .getProperties().stream()
                 .filter( ownablePropertyTypes::contains )
                 .map( ptId -> dms.getPropertyType( ptId ).getType() )
+                .map( fqn -> fqn.toString() )
                 .collect( Collectors.toCollection( () -> new LinkedHashSet<>() ) );
         
         Map<UUID, Map<UUID, PropertyType>> authorizedPropertyTypesForEntitySets = new HashMap<>();
@@ -151,7 +152,7 @@ public class LinkingService {
         }
 
         // Consume the iterable to trigger indexing!
-        cdm.getLinkedEntitySetData( linkedEntitySetId, orderedPropertyFqns, authorizedPropertyTypesForEntitySets ).getEntities().forEach( m -> {} );
+        cdm.getLinkedEntitySetData( linkedEntitySetId, orderedPropertyNames, authorizedPropertyTypesForEntitySets ).getEntities().forEach( m -> {} );
     }
 
     private LinkingEdge fromUnorderedPair( UUID graphId, UnorderedPair<Entity> p ) {

--- a/src/test/java/com/dataloom/datastore/data/DataManagerTest.java
+++ b/src/test/java/com/dataloom/datastore/data/DataManagerTest.java
@@ -109,8 +109,9 @@ public class DataManagerTest extends BootstrapDatastoreWithCassandra {
         final UUID syncId = UUIDs.timeBased();
 
         LinkedHashMap<UUID, PropertyType> propertyTypes = generateProperties( 5 );
-        LinkedHashSet<FullQualifiedName> orderedPropertyFqns = propertyTypes.entrySet().stream()
+        LinkedHashSet<String> orderedPropertyNames = propertyTypes.entrySet().stream()
                 .map( entry -> entry.getValue().getType() )
+                .map( fqn -> fqn.toString() )
                 .collect( Collectors.toCollection( () -> new LinkedHashSet<>() ) );
         Map<UUID, EdmPrimitiveTypeKind> propertiesWithDataType = propertyTypes.entrySet().stream()
                 .collect( Collectors.toMap( e -> e.getKey(), e -> e.getValue().getDatatype() ) );
@@ -119,7 +120,7 @@ public class DataManagerTest extends BootstrapDatastoreWithCassandra {
         testWriteData( entitySetId, syncId, entities, propertiesWithDataType );
         Set<SetMultimap<FullQualifiedName, Object>> result = testReadData( syncId,
                 entitySetId,
-                orderedPropertyFqns,
+                orderedPropertyNames,
                 propertyTypes );
 
         Set<SetMultimap<FullQualifiedName, Object>> expected = convertGeneratedDataFromUuidToFqn( entities );
@@ -140,8 +141,9 @@ public class DataManagerTest extends BootstrapDatastoreWithCassandra {
         final UUID secondSyncId = UUIDs.timeBased();
 
         LinkedHashMap<UUID, PropertyType> propertyTypes = generateProperties( 5 );
-        LinkedHashSet<FullQualifiedName> orderedPropertyFqns = propertyTypes.entrySet().stream()
+        LinkedHashSet<String> orderedPropertyNames = propertyTypes.entrySet().stream()
                 .map( entry -> entry.getValue().getType() )
+                .map( fqn -> fqn.toString() )
                 .collect( Collectors.toCollection( () -> new LinkedHashSet<>() ) );
         Map<UUID, EdmPrimitiveTypeKind> propertiesWithDataType = propertyTypes.entrySet().stream()
                 .collect( Collectors.toMap( e -> e.getKey(), e -> e.getValue().getDatatype() ) );
@@ -156,7 +158,7 @@ public class DataManagerTest extends BootstrapDatastoreWithCassandra {
 
         Assert.assertEquals( 0, testReadData( secondSyncId,
                 entitySetId,
-                orderedPropertyFqns,
+                orderedPropertyNames,
                 propertyTypes ).size() );
     }
 
@@ -215,10 +217,10 @@ public class DataManagerTest extends BootstrapDatastoreWithCassandra {
     public Set<SetMultimap<FullQualifiedName, Object>> testReadData(
             UUID syncId,
             UUID entitySetId,
-            LinkedHashSet<FullQualifiedName> orderedPropertyFqns,
+            LinkedHashSet<String> orderedPropertyNames,
             Map<UUID, PropertyType> propertyTypes ) {
         return Sets.newHashSet(
-                dataService.getEntitySetData( entitySetId, syncId, orderedPropertyFqns, propertyTypes ).getEntities() );
+                dataService.getEntitySetData( entitySetId, syncId, orderedPropertyNames, propertyTypes ).getEntities() );
     }
 
     private LinkedHashMap<UUID, PropertyType> generateProperties( int n ) {

--- a/src/test/java/com/dataloom/datastore/data/DataManagerTest.java
+++ b/src/test/java/com/dataloom/datastore/data/DataManagerTest.java
@@ -30,6 +30,7 @@ import java.util.Base64;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
@@ -41,9 +42,9 @@ import java.util.stream.Collectors;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.olingo.commons.api.edm.EdmPrimitiveTypeKind;
 import org.apache.olingo.commons.api.edm.FullQualifiedName;
-import org.apache.olingo.commons.api.edm.geo.SRID;
 import org.apache.olingo.commons.api.edm.geo.Geospatial.Dimension;
 import org.apache.olingo.commons.api.edm.geo.Point;
+import org.apache.olingo.commons.api.edm.geo.SRID;
 import org.joda.time.DateTime;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -68,8 +69,8 @@ public class DataManagerTest extends BootstrapDatastoreWithCassandra {
     private static final int                        edmTypesSize;
 
     private static final Random                     random   = new Random();
-    private static final SRID srid = SRID.valueOf( "4326" );
-    private static final Base64.Encoder encoder = Base64.getUrlEncoder();
+    private static final SRID                       srid     = SRID.valueOf( "4326" );
+    private static final Base64.Encoder             encoder  = Base64.getUrlEncoder();
     private static ObjectMapper                     mapper;
 
     static {
@@ -96,10 +97,10 @@ public class DataManagerTest extends BootstrapDatastoreWithCassandra {
 
     @BeforeClass
     public static void initDMTest() {
-//        if ( initLock.readLock().tryLock() ) {
-            mapper = ds.getContext().getBean( ObjectMapper.class );
-//        }
-//        initLock.readLock().unlock();
+        // if ( initLock.readLock().tryLock() ) {
+        mapper = ds.getContext().getBean( ObjectMapper.class );
+        // }
+        // initLock.readLock().unlock();
     }
 
     @Test
@@ -107,7 +108,10 @@ public class DataManagerTest extends BootstrapDatastoreWithCassandra {
         final UUID entitySetId = UUID.randomUUID();
         final UUID syncId = UUIDs.timeBased();
 
-        Map<UUID, PropertyType> propertyTypes = generateProperties( 5 );
+        LinkedHashMap<UUID, PropertyType> propertyTypes = generateProperties( 5 );
+        LinkedHashSet<FullQualifiedName> orderedPropertyFqns = propertyTypes.entrySet().stream()
+                .map( entry -> entry.getValue().getType() )
+                .collect( Collectors.toCollection( () -> new LinkedHashSet<>() ) );
         Map<UUID, EdmPrimitiveTypeKind> propertiesWithDataType = propertyTypes.entrySet().stream()
                 .collect( Collectors.toMap( e -> e.getKey(), e -> e.getValue().getDatatype() ) );
         Map<String, SetMultimap<UUID, Object>> entities = generateData( 10, propertiesWithDataType, 1 );
@@ -115,27 +119,33 @@ public class DataManagerTest extends BootstrapDatastoreWithCassandra {
         testWriteData( entitySetId, syncId, entities, propertiesWithDataType );
         Set<SetMultimap<FullQualifiedName, Object>> result = testReadData( syncId,
                 entitySetId,
+                orderedPropertyFqns,
                 propertyTypes );
 
         Set<SetMultimap<FullQualifiedName, Object>> expected = convertGeneratedDataFromUuidToFqn( entities );
 
-        Map<FullQualifiedName, EdmPrimitiveTypeKind> propertiesWithDataTypeIndexedByFqn = propertyTypes.entrySet().stream()
+        Map<FullQualifiedName, EdmPrimitiveTypeKind> propertiesWithDataTypeIndexedByFqn = propertyTypes.entrySet()
+                .stream()
                 .collect( Collectors.toMap( e -> e.getValue().getType(), e -> e.getValue().getDatatype() ) );
-        
-        Assert.assertEquals( convertValueToString( expected, propertiesWithDataTypeIndexedByFqn, this::getStringFromRaw ), convertValueToString( result, propertiesWithDataTypeIndexedByFqn, this::getStringFromNormalized ) );
+
+        Assert.assertEquals(
+                convertValueToString( expected, propertiesWithDataTypeIndexedByFqn, this::getStringFromRaw ),
+                convertValueToString( result, propertiesWithDataTypeIndexedByFqn, this::getStringFromNormalized ) );
     }
-    
-    
+
     @Test
     public void testWriteAndDelete() {
         final UUID entitySetId = UUID.randomUUID();
         final UUID firstSyncId = UUIDs.timeBased();
         final UUID secondSyncId = UUIDs.timeBased();
 
-        Map<UUID, PropertyType> propertyTypes = generateProperties( 5 );
+        LinkedHashMap<UUID, PropertyType> propertyTypes = generateProperties( 5 );
+        LinkedHashSet<FullQualifiedName> orderedPropertyFqns = propertyTypes.entrySet().stream()
+                .map( entry -> entry.getValue().getType() )
+                .collect( Collectors.toCollection( () -> new LinkedHashSet<>() ) );
         Map<UUID, EdmPrimitiveTypeKind> propertiesWithDataType = propertyTypes.entrySet().stream()
                 .collect( Collectors.toMap( e -> e.getKey(), e -> e.getValue().getDatatype() ) );
-        
+
         Map<String, SetMultimap<UUID, Object>> firstEntities = generateData( 10, propertiesWithDataType, 1 );
         testWriteData( entitySetId, firstSyncId, firstEntities, propertiesWithDataType );
 
@@ -143,9 +153,10 @@ public class DataManagerTest extends BootstrapDatastoreWithCassandra {
         testWriteData( entitySetId, secondSyncId, secondEntities, propertiesWithDataType );
 
         dataService.deleteEntitySetData( entitySetId );
-        
+
         Assert.assertEquals( 0, testReadData( secondSyncId,
                 entitySetId,
+                orderedPropertyFqns,
                 propertyTypes ).size() );
     }
 
@@ -204,13 +215,15 @@ public class DataManagerTest extends BootstrapDatastoreWithCassandra {
     public Set<SetMultimap<FullQualifiedName, Object>> testReadData(
             UUID syncId,
             UUID entitySetId,
+            LinkedHashSet<FullQualifiedName> orderedPropertyFqns,
             Map<UUID, PropertyType> propertyTypes ) {
-        return Sets.newHashSet( dataService.getEntitySetData( entitySetId, syncId, propertyTypes ).getEntities() );
+        return Sets.newHashSet(
+                dataService.getEntitySetData( entitySetId, syncId, orderedPropertyFqns, propertyTypes ).getEntities() );
     }
 
-    private Map<UUID, PropertyType> generateProperties( int n ) {
+    private LinkedHashMap<UUID, PropertyType> generateProperties( int n ) {
         System.out.println( "Generating Properties..." );
-        Map<UUID, PropertyType> propertyTypes = new HashMap<>();
+        LinkedHashMap<UUID, PropertyType> propertyTypes = new LinkedHashMap<>();
         for ( int i = 0; i < n; i++ ) {
             UUID propertyId = UUID.randomUUID();
             propertyTypes.put( propertyId, getRandomPropertyType( propertyId ) );
@@ -313,7 +326,7 @@ public class DataManagerTest extends BootstrapDatastoreWithCassandra {
     }
 
     private PropertyType getRandomPropertyType( UUID id ) {
-//        EdmPrimitiveTypeKind type = getRandomEdmType();
+        // EdmPrimitiveTypeKind type = getRandomEdmType();
         EdmPrimitiveTypeKind type = EdmPrimitiveTypeKind.Date;
         return new PropertyType(
                 id,
@@ -338,7 +351,7 @@ public class DataManagerTest extends BootstrapDatastoreWithCassandra {
         Object rawObj;
         switch ( type ) {
             case Binary:
-                byte[] b = new byte[10];
+                byte[] b = new byte[ 10 ];
                 random.nextBytes( b );
                 rawObj = encoder.encode( b );
                 break;
@@ -362,7 +375,8 @@ public class DataManagerTest extends BootstrapDatastoreWithCassandra {
                 rawObj = random.nextDouble();
                 break;
             case Duration:
-                rawObj = "P" + random.nextInt( 30 ) + "D" + "T" + random.nextInt( 24 ) + "H" + random.nextInt( 60 ) + "M"
+                rawObj = "P" + random.nextInt( 30 ) + "D" + "T" + random.nextInt( 24 ) + "H" + random.nextInt( 60 )
+                        + "M"
                         + random.nextInt( 60 )
                         + "S";
                 break;
@@ -416,37 +430,37 @@ public class DataManagerTest extends BootstrapDatastoreWithCassandra {
         Set<SetMultimap<FullQualifiedName, String>> result = new HashSet<>();
         for ( SetMultimap<FullQualifiedName, Object> map : set ) {
             SetMultimap<FullQualifiedName, String> ans = HashMultimap.create();
-            map.entries().stream().forEach( e -> ans.put( e.getKey(), getStringFunction.apply( e.getValue(), propertiesWithDataTypeIndexedByFqn.get( e.getKey() ) ) ) );
+            map.entries().stream().forEach( e -> ans.put( e.getKey(),
+                    getStringFunction.apply( e.getValue(), propertiesWithDataTypeIndexedByFqn.get( e.getKey() ) ) ) );
             result.add( ans );
         }
         return result;
     }
-    
+
     /**
      * Generate a random double within [-a,a]
      */
-    private static double randomDouble( double a ){
-        return 2*a*random.nextDouble() - a;
+    private static double randomDouble( double a ) {
+        return 2 * a * random.nextDouble() - a;
     }
-    
-    private String getStringFromNormalized( Object value, EdmPrimitiveTypeKind type ){
-        switch ( type ){
+
+    private String getStringFromNormalized( Object value, EdmPrimitiveTypeKind type ) {
+        switch ( type ) {
             case Binary:
-                return encoder.encodeToString( ((ByteBuffer) value ).array() );
+                return encoder.encodeToString( ( (ByteBuffer) value ).array() );
             default:
                 return value.toString();
         }
     }
 
-    @SuppressWarnings( "unchecked" )    
-    private String getStringFromRaw( Object value, EdmPrimitiveTypeKind type ){
-        switch ( type ){
+    @SuppressWarnings( "unchecked" )
+    private String getStringFromRaw( Object value, EdmPrimitiveTypeKind type ) {
+        switch ( type ) {
             case GeographyPoint:
-                if( value instanceof LinkedHashMap ){
+                if ( value instanceof LinkedHashMap ) {
                     LinkedHashMap<String, Object> point = (LinkedHashMap<String, Object>) value;
                     return point.get( "y" ) + "," + point.get( "x" );
-                }
-                else if( value instanceof Point ){
+                } else if ( value instanceof Point ) {
                     Point point = (Point) value;
                     return point.getY() + "," + point.getX();
                 }


### PR DESCRIPTION
Endpoints in `DataGraphManager` for reading entity sets now require an extra param of `orderedPropertyFqns`, which is a `LinkedHashSet` of property types names, in the same order when the entity type is created. 

Accordingly,
- update `loadEntitySetData`, `loadNormalEntitySetData`, `loadLinkedEntitySetData` endpoints in `DataController`
- update `mergeEntities` endpoint in `LinkingService`
- update `DataManagerTest`