### PR TITLE
Added apps to new Organization().

### DIFF
--- a/src/main/java/com/openlattice/controllers/OrganizationsController.java
+++ b/src/main/java/com/openlattice/controllers/OrganizationsController.java
@@ -113,7 +113,8 @@ public class OrganizationsController implements AuthorizingComponent, Organizati
                 org.getSecurablePrincipal(),
                 org.getAutoApprovedEmails(),
                 org.getMembers(),
-                authorizedRoles );
+                authorizedRoles,
+                org.getApps() );
     }
 
     @Override


### PR DESCRIPTION
This change, along with change to conductor-client HazelcastOrganizationService.java I think solves the issue of apps not being included in organization information.