### PR TITLE
LATTICE-1915 Deleting all entities from an entity set enumerates all entityKeyIds

### DIFF
--- a/src/main/java/com/openlattice/datastore/data/controllers/DataController.java
+++ b/src/main/java/com/openlattice/datastore/data/controllers/DataController.java
@@ -670,6 +670,11 @@ public class DataController implements DataApi, AuthorizingComponent, AuditingCo
             @PathVariable( ENTITY_SET_ID ) UUID entitySetId,
             @RequestBody Set<UUID> entityKeyIds,
             @RequestParam( value = TYPE ) DeleteType deleteType ) {
+
+        if ( entityKeyIds.size() == dgm.getEntitySetSize( entitySetId ) ) {
+            return deleteAllEntitiesFromEntitySet( entitySetId, deleteType );
+        }
+
         WriteEvent writeEvent;
         if ( deleteType == DeleteType.Hard ) {
             // access checks for entity set and properties

--- a/src/main/java/com/openlattice/datastore/data/controllers/DataController.java
+++ b/src/main/java/com/openlattice/datastore/data/controllers/DataController.java
@@ -671,8 +671,8 @@ public class DataController implements DataApi, AuthorizingComponent, AuditingCo
             @RequestBody Set<UUID> entityKeyIds,
             @RequestParam( value = TYPE ) DeleteType deleteType ) {
 
-        if ( entityKeyIds.size() == dgm.getEntitySetSize( entitySetId ) ) {
-            return deleteAllEntitiesFromEntitySet( entitySetId, deleteType );
+        if ( entityKeyIds.size() > MAX_BATCH_SIZE ) {
+            throw new IllegalArgumentException( "You can only delete entities in batches of up to " + MAX_BATCH_SIZE + " per request." );
         }
 
         WriteEvent writeEvent;


### PR DESCRIPTION
This PR:
- Updates `deleteEntities` to call a more efficient method when deleting an entire entity set

Notes:
- Unsure whether this is the correct fix since the audit logging will say that `deleteAllEntitiesFromEntitySet` was used rather than `deleteEntities`
- May be better to just return a 400 and recommend calling `deleteAllEntitiesFromEntitySet`