### PR TITLE
Feature/lattice 2312 audit external db

### DIFF
--- a/src/main/kotlin/com/openlattice/organizations/DatasetController.kt
+++ b/src/main/kotlin/com/openlattice/organizations/DatasetController.kt
@@ -111,9 +111,9 @@ class DatasetController : DatasetApi, AuthorizingComponent {
     override fun getExternalDatabaseTable(
             @PathVariable(ID) organizationId: UUID,
             @PathVariable(TABLE_NAME) tableName: String): OrganizationExternalDatabaseTable {
-        val tableFqnToId = getExternalDatabaseObjectFqnToIdPair(organizationId, tableName)
-        ensureReadAccess(AclKey(tableFqnToId.second))
-        return edms.getOrganizationExternalDatabaseTable(tableFqnToId.second)
+        val (_, tableId) = getExternalDatabaseObjectFqnToIdPair(organizationId, tableName)
+        ensureReadAccess(AclKey(tableId))
+        return edms.getOrganizationExternalDatabaseTable(tableId)
     }
 
     @Timed
@@ -122,10 +122,10 @@ class DatasetController : DatasetApi, AuthorizingComponent {
             @PathVariable(ID) organizationId: UUID,
             @PathVariable(TABLE_NAME) tableName: String,
             @PathVariable(COLUMN_NAME) columnName: String): OrganizationExternalDatabaseColumn {
-        val tableFqnToId = getExternalDatabaseObjectFqnToIdPair(organizationId, tableName)
-        val columnFqnToId = getExternalDatabaseObjectFqnToIdPair(tableFqnToId.second, columnName)
-        ensureReadAccess(AclKey(tableFqnToId.second, columnFqnToId.second))
-        return edms.getOrganizationExternalDatabaseColumn(columnFqnToId.second)
+        val (_, tableId) = getExternalDatabaseObjectFqnToIdPair(organizationId, tableName)
+        val (_, columnId) = getExternalDatabaseObjectFqnToIdPair(tableId, columnName)
+        ensureReadAccess(AclKey(tableId, columnId))
+        return edms.getOrganizationExternalDatabaseColumn(columnId)
     }
 
     //TODO Metadata update probably won't work
@@ -135,8 +135,8 @@ class DatasetController : DatasetApi, AuthorizingComponent {
             @PathVariable(ID) organizationId: UUID,
             @PathVariable(TABLE_NAME) tableName: String,
             @RequestBody metadataUpdate: MetadataUpdate) {
-        val tableFqnToId = getExternalDatabaseObjectFqnToIdPair(organizationId, tableName)
         ensureAdminAccess()
+        val tableFqnToId = getExternalDatabaseObjectFqnToIdPair(organizationId, tableName)
         edms.updateOrganizationExternalDatabaseTable(organizationId, tableFqnToId, metadataUpdate)
     }
 
@@ -147,9 +147,9 @@ class DatasetController : DatasetApi, AuthorizingComponent {
             @PathVariable(TABLE_NAME) tableName: String,
             @PathVariable(COLUMN_NAME) columnName: String,
             @RequestBody metadataUpdate: MetadataUpdate) {
+        ensureAdminAccess()
         val tableFqnToId = getExternalDatabaseObjectFqnToIdPair(organizationId, tableName)
         val columnFqnToId = getExternalDatabaseObjectFqnToIdPair(tableFqnToId.second, columnName)
-        ensureAdminAccess()
         edms.updateOrganizationExternalDatabaseColumn(organizationId, tableFqnToId, columnFqnToId, metadataUpdate)
     }
 
@@ -162,7 +162,7 @@ class DatasetController : DatasetApi, AuthorizingComponent {
         val aclKey = AclKey(tableFqnToId.second)
         ensureOwnerAccess(aclKey)
         ensureObjectCanBeDeleted(tableFqnToId.second)
-        edms.deleteOrganizationExternalDatabaseTable(organizationId, tableFqnToId)
+        edms.deleteOrganizationExternalDatabaseTables(organizationId, mapOf(tableFqnToId))
     }
 
     @Timed
@@ -191,7 +191,7 @@ class DatasetController : DatasetApi, AuthorizingComponent {
         val aclKey = AclKey(tableFqnToId.second, columnFqnToId.second)
         ensureOwnerAccess(aclKey)
         ensureObjectCanBeDeleted(columnFqnToId.second)
-        edms.deleteOrganizationExternalDatabaseColumn(organizationId, tableFqnToId, columnFqnToId)
+        edms.deleteOrganizationExternalDatabaseColumns(organizationId, mapOf(tableFqnToId to mapOf(columnFqnToId)))
     }
 
     @Timed

--- a/src/main/kotlin/com/openlattice/organizations/DatasetController.kt
+++ b/src/main/kotlin/com/openlattice/organizations/DatasetController.kt
@@ -141,7 +141,7 @@ class DatasetController : DatasetApi, AuthorizingComponent {
     }
 
     @Timed
-    @PatchMapping(path = [ID_PATH + TABLE_NAME_PATH + COLUMN_NAME_PATH + EXTERNAL_DATABASE_TABLE])
+    @PatchMapping(path = [ID_PATH + TABLE_NAME_PATH + COLUMN_NAME_PATH + EXTERNAL_DATABASE_COLUMN])
     override fun updateExternalDatabaseColumn(
             @PathVariable(ID) organizationId: UUID,
             @PathVariable(TABLE_NAME) tableName: String,

--- a/src/main/kotlin/com/openlattice/organizations/DatasetController.kt
+++ b/src/main/kotlin/com/openlattice/organizations/DatasetController.kt
@@ -20,11 +20,6 @@ import org.springframework.web.bind.annotation.PostMapping
 import com.openlattice.edm.requests.MetadataUpdate
 import org.springframework.web.bind.annotation.PatchMapping
 
-
-
-
-
-
 @SuppressFBWarnings(
         value = ["BC_BAD_CAST_TO_ABSTRACT_COLLECTION"],
         justification = "Allowing kotlin collection mapping cast to List")

--- a/src/main/kotlin/com/openlattice/organizations/DatasetController.kt
+++ b/src/main/kotlin/com/openlattice/organizations/DatasetController.kt
@@ -77,48 +77,6 @@ class DatasetController : DatasetApi, AuthorizingComponent {
     }
 
     @Timed
-    @PostMapping(path = [ID_PATH + EXTERNAL_DATABASE_TABLE])
-    override fun createExternalDatabaseTable(
-            @PathVariable(ID) organizationId: UUID,
-            @RequestBody organizationExternalDatabaseTable: OrganizationExternalDatabaseTable): UUID {
-        ensureOwnerAccess(AclKey(organizationId))
-        return edms.createOrganizationExternalDatabaseTable(organizationId, organizationExternalDatabaseTable)
-    }
-
-    @Timed
-    @PostMapping(path = [ID_PATH + EXTERNAL_DATABASE_COLUMN])
-    override fun createExternalDatabaseColumn(
-            @PathVariable(ID) organizationId: UUID,
-            @RequestBody organizationExternalDatabaseColumn: OrganizationExternalDatabaseColumn): UUID {
-        ensureOwnerAccess(AclKey(organizationId))
-        return edms.createOrganizationExternalDatabaseColumn(organizationId, organizationExternalDatabaseColumn)
-    }
-
-    @Timed
-    @PostMapping(path = [ID_PATH + TABLE_NAME_PATH + EXTERNAL_DATABASE_TABLE])
-    fun createNewExternalDatabaseTable(
-            @PathVariable(ID) organizationId: UUID,
-            @PathVariable(TABLE_NAME) tableName: String,
-            @RequestBody columnNameToMetadata: Map<String, OrganizationExternalDatabaseColumnMetadata>) {
-        ensureOwnerAccess(AclKey(organizationId))
-        edms.createNewOrganizationExternalDatabaseTable(organizationId, tableName, columnNameToMetadata)
-    }
-
-
-    @Timed
-    @PostMapping(path = [ID_PATH + TABLE_NAME_PATH + COLUMN_NAME_PATH + SQL_TYPE_PATH + EXTERNAL_DATABASE_COLUMN])
-    fun createNewExternalDatabaseColumn(
-            @PathVariable(ID) organizationId: UUID,
-            @PathVariable(TABLE_NAME) tableName: String,
-            @PathVariable(COLUMN_NAME) columnName: String,
-            @PathVariable(SQL_TYPE) sqlType: String) {
-        ensureOwnerAccess(organizationId)
-        val tableId = getExternalDatabaseObjectId(organizationId, tableName)
-        edms.createNewOrganizationExternalDatabaseColumn(organizationId, tableId, tableName, columnName, sqlType)
-    }
-
-
-    @Timed
     @GetMapping(path = [ID_PATH + EXTERNAL_DATABASE_TABLE])
     override fun getExternalDatabaseTables(
             @PathVariable(ID) organizationId: UUID): Set<OrganizationExternalDatabaseTable> {

--- a/src/main/kotlin/com/openlattice/organizations/DatasetController.kt
+++ b/src/main/kotlin/com/openlattice/organizations/DatasetController.kt
@@ -158,11 +158,7 @@ class DatasetController : DatasetApi, AuthorizingComponent {
     override fun deleteExternalDatabaseTable(
             @PathVariable(ID) organizationId: UUID,
             @PathVariable(TABLE_NAME) tableName: String) {
-        val tableFqnToId = getExternalDatabaseObjectFqnToIdPair(organizationId, tableName)
-        val aclKey = AclKey(tableFqnToId.second)
-        ensureOwnerAccess(aclKey)
-        ensureObjectCanBeDeleted(tableFqnToId.second)
-        edms.deleteOrganizationExternalDatabaseTables(organizationId, mapOf(tableFqnToId))
+        deleteExternalDatabaseTables(organizationId, setOf(tableName))
     }
 
     @Timed
@@ -186,12 +182,7 @@ class DatasetController : DatasetApi, AuthorizingComponent {
             @PathVariable(TABLE_NAME) tableName: String,
             @PathVariable(COLUMN_NAME) columnName: String
     ) {
-        val tableFqnToId = getExternalDatabaseObjectFqnToIdPair(organizationId, tableName)
-        val columnFqnToId = getExternalDatabaseObjectFqnToIdPair(tableFqnToId.second, columnName)
-        val aclKey = AclKey(tableFqnToId.second, columnFqnToId.second)
-        ensureOwnerAccess(aclKey)
-        ensureObjectCanBeDeleted(columnFqnToId.second)
-        edms.deleteOrganizationExternalDatabaseColumns(organizationId, mapOf(tableFqnToId to mapOf(columnFqnToId)))
+        deleteExternalDatabaseColumns(organizationId, tableName, setOf(columnName))
     }
 
     @Timed

--- a/src/main/kotlin/com/openlattice/organizations/DatasetController.kt
+++ b/src/main/kotlin/com/openlattice/organizations/DatasetController.kt
@@ -97,7 +97,7 @@ class DatasetController : DatasetApi, AuthorizingComponent {
     override fun getExternalDatabaseTableWithColumns(
             @PathVariable(ID) organizationId: UUID,
             @PathVariable(TABLE_ID) tableId: UUID): OrganizationExternalDatabaseTableColumnsPair {
-        ensureReadAccess(AclKey(organizationId, tableId))
+        ensureReadAccess(AclKey(tableId))
         return edms.getExternalDatabaseTableWithColumns(tableId)
     }
 
@@ -107,7 +107,7 @@ class DatasetController : DatasetApi, AuthorizingComponent {
             @PathVariable(ID) organizationId: UUID,
             @PathVariable(TABLE_ID) tableId: UUID,
             @PathVariable(ROW_COUNT) rowCount: Int): Map<UUID, List<Any?>> {
-        ensureReadAccess(AclKey(organizationId, tableId))
+        ensureReadAccess(AclKey(tableId))
         return edms.getExternalDatabaseTableData(organizationId, tableId, rowCount)
     }
 
@@ -164,7 +164,7 @@ class DatasetController : DatasetApi, AuthorizingComponent {
             @PathVariable(ID) organizationId: UUID,
             @PathVariable(TABLE_NAME) tableName: String) {
         val tableId = getExternalDatabaseObjectId(organizationId, tableName)
-        val aclKey = AclKey(organizationId, tableId)
+        val aclKey = AclKey(tableId)
         ensureOwnerAccess(aclKey)
         ensureObjectCanBeDeleted(tableId)
         edms.deleteOrganizationExternalDatabaseTable(organizationId, tableId)
@@ -177,7 +177,7 @@ class DatasetController : DatasetApi, AuthorizingComponent {
             @RequestBody tableNames: Set<String>) {
         val tableIds = getExternalDatabaseObjectIds(organizationId, tableNames)
         tableIds.forEach { ensureObjectCanBeDeleted(it) }
-        val aclKeys = tableIds.map { AclKey(organizationId, it) }.toSet()
+        val aclKeys = tableIds.map { AclKey(it) }.toSet()
         aclKeys.forEach { aclKey ->
             ensureOwnerAccess(aclKey)
         }
@@ -193,7 +193,7 @@ class DatasetController : DatasetApi, AuthorizingComponent {
     ) {
         val tableId = getExternalDatabaseObjectId(organizationId, tableName)
         val columnId = getExternalDatabaseObjectId(tableId, columnName)
-        val aclKey = AclKey(organizationId, tableId, columnId)
+        val aclKey = AclKey(tableId, columnId)
         ensureOwnerAccess(aclKey)
         ensureObjectCanBeDeleted(columnId)
         edms.deleteOrganizationExternalDatabaseColumn(organizationId, tableId, columnId)
@@ -209,7 +209,7 @@ class DatasetController : DatasetApi, AuthorizingComponent {
         val tableId = getExternalDatabaseObjectId(organizationId, tableName)
         val columnIds = getExternalDatabaseObjectIds(tableId, columnNames)
         columnIds.forEach { ensureObjectCanBeDeleted(it) }
-        val aclKeys = columnIds.map { AclKey(organizationId, tableId, it) }.toSet()
+        val aclKeys = columnIds.map { AclKey(tableId, it) }.toSet()
         aclKeys.forEach { aclKey ->
             ensureOwnerAccess(aclKey)
         }

--- a/src/main/kotlin/com/openlattice/organizations/DatasetController.kt
+++ b/src/main/kotlin/com/openlattice/organizations/DatasetController.kt
@@ -117,7 +117,7 @@ class DatasetController : DatasetApi, AuthorizingComponent {
             @PathVariable(ID) organizationId: UUID,
             @PathVariable(TABLE_NAME) tableName: String): OrganizationExternalDatabaseTable {
         val tableId = getExternalDatabaseObjectId(organizationId, tableName)
-        ensureReadAccess(AclKey(organizationId, tableId))
+        ensureReadAccess(AclKey(tableId))
         return edms.getOrganizationExternalDatabaseTable(tableId)
     }
 
@@ -129,7 +129,7 @@ class DatasetController : DatasetApi, AuthorizingComponent {
             @PathVariable(COLUMN_NAME) columnName: String): OrganizationExternalDatabaseColumn {
         val tableId = getExternalDatabaseObjectId(organizationId, tableName)
         val columnId = getExternalDatabaseObjectId(tableId, columnName)
-        ensureReadAccess(AclKey(organizationId, tableId, columnId))
+        ensureReadAccess(AclKey(tableId, columnId))
         return edms.getOrganizationExternalDatabaseColumn(columnId)
     }
 


### PR DESCRIPTION
-Creates controller for updating columns/tables
-Removes organization id from table/column acl keys
-Keeps column/table names mapped to ids for downstream processing