### PR TITLE
LATTICE 2419 Permissions fixes for External DB tables

### DIFF
--- a/src/main/kotlin/com/openlattice/organizations/DatasetController.kt
+++ b/src/main/kotlin/com/openlattice/organizations/DatasetController.kt
@@ -73,8 +73,8 @@ class DatasetController : DatasetApi, AuthorizingComponent {
     override fun getExternalDatabaseTables(
             @PathVariable(ID) organizationId: UUID): Set<OrganizationExternalDatabaseTable> {
         val tables = edms.getExternalDatabaseTables(organizationId)
-        val authorizedTableIds = getAuthorizedTableIds(tables.keys, Permission.READ)
-        return tables.filter { it.key in authorizedTableIds }.values.toSet()
+        val authorizedTableIds = getAuthorizedTableIds(tables.map { it.key }.toSet(), Permission.READ)
+        return tables.filter { it.key in authorizedTableIds }.map { it.value }.toSet()
     }
 
     @Timed
@@ -86,9 +86,9 @@ class DatasetController : DatasetApi, AuthorizingComponent {
         val columnsByAuthorizedTable = columnsByTable.filter { it.key.first in authorizedTableIds }
         return columnsByAuthorizedTable.map {
             it.key.second to it.value.filter { (columnId, _) ->
-                val authorizedColumnIds = getAuthorizedColumnIds(it.key.first, it.value.keys, Permission.READ)
+                val authorizedColumnIds = getAuthorizedColumnIds(it.key.first, it.value.map { entry -> entry.key }.toSet(), Permission.READ)
                 columnId in authorizedColumnIds
-            }.values.toSet()
+            }.map { entry -> entry.value }.toSet()
         }.toMap()
     }
 

--- a/src/main/kotlin/com/openlattice/organizations/DatasetController.kt
+++ b/src/main/kotlin/com/openlattice/organizations/DatasetController.kt
@@ -75,9 +75,9 @@ class DatasetController : DatasetApi, AuthorizingComponent {
     override fun getExternalDatabaseTablesWithColumns(
             @PathVariable(ID) organizationId: UUID): Map<OrganizationExternalDatabaseTable, Set<OrganizationExternalDatabaseColumn>> {
         val authorizedColsByTable = mutableMapOf<OrganizationExternalDatabaseTable, Set<OrganizationExternalDatabaseColumn>>()
-        edms.getExternalDatabaseTablesWithColumns(organizationId).forEach { (key, value) ->
-            if (isAuthorized(Permission.READ).test(AclKey(key.id))) {
-                authorizedColsByTable[key] = value.filter { isAuthorized(Permission.READ).test(AclKey(it.id)) }.toSet()
+        edms.getExternalDatabaseTablesWithColumns(organizationId).forEach { (table, columns) ->
+            if (isAuthorized(Permission.READ).test(AclKey(table.id))) {
+                authorizedColsByTable[table] = columns.filter { isAuthorized(Permission.READ).test(AclKey(it.id)) }.toSet()
             }
         }
         return authorizedColsByTable

--- a/src/main/kotlin/com/openlattice/organizations/DatasetController.kt
+++ b/src/main/kotlin/com/openlattice/organizations/DatasetController.kt
@@ -11,7 +11,6 @@ import com.openlattice.organization.OrganizationExternalDatabaseTableColumnsPair
 import com.openlattice.postgres.PostgresConnectionType
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings
 import org.apache.olingo.commons.api.edm.FullQualifiedName
-import org.slf4j.LoggerFactory
 import org.springframework.web.bind.annotation.*
 import java.util.*
 import javax.inject.Inject
@@ -23,10 +22,6 @@ import javax.inject.Inject
 @RestController
 @RequestMapping(CONTROLLER)
 class DatasetController : DatasetApi, AuthorizingComponent {
-
-    companion object {
-        private val logger = LoggerFactory.getLogger(DatasetController::class.java)
-    }
 
     @Inject
     private lateinit var edms: ExternalDatabaseManagementService

--- a/src/main/kotlin/com/openlattice/organizations/DatasetController.kt
+++ b/src/main/kotlin/com/openlattice/organizations/DatasetController.kt
@@ -90,12 +90,16 @@ class DatasetController : DatasetApi, AuthorizingComponent {
         val columnsByAuthorizedTable = columnsByTable.filter { it.key in authorizedTables }
         return columnsByAuthorizedTable.map {
             it.key to it.value.filter { (columnId, _) ->
+
+                //creates set of columnIds that the user is authorized to read
                 val authorizedColumnIds = authorizations.accessChecksForPrincipals(
                         it.value.keys.map { columnId -> AccessCheck(AclKey(columnId), EnumSet.of(Permission.READ)) }.toSet(),
                         Principals.getCurrentPrincipals()
                 )
                         .filter { authz -> authz.permissions.contains(Permission.READ) }
                         .map { authz -> authz.aclKey[0] }.collect(Collectors.toSet())
+
+                //performs the filter for authorized columnIds
                 columnId in authorizedColumnIds
             }.values.toSet()
         }.toMap()

--- a/src/main/kotlin/com/openlattice/organizations/DatasetController.kt
+++ b/src/main/kotlin/com/openlattice/organizations/DatasetController.kt
@@ -70,14 +70,14 @@ class DatasetController : DatasetApi, AuthorizingComponent {
 
     @Timed
     @GetMapping(path = [ID_PATH + EXTERNAL_DATABASE_TABLE])
-    override fun getAuthorizedExternalDatabaseTables(
+    override fun getExternalDatabaseTables(
             @PathVariable(ID) organizationId: UUID): Set<OrganizationExternalDatabaseTable> {
         return edms.getExternalDatabaseTables(organizationId).filter { isAuthorized(Permission.READ).test(AclKey(it.id)) }.toSet()
     }
 
     @Timed
     @GetMapping(path = [ID_PATH + EXTERNAL_DATABASE_TABLE + EXTERNAL_DATABASE_COLUMN])
-    override fun getAuthorizedExternalDatabaseTablesWithColumns(
+    override fun getExternalDatabaseTablesWithColumns(
             @PathVariable(ID) organizationId: UUID): Map<OrganizationExternalDatabaseTable, Set<OrganizationExternalDatabaseColumn>> {
         val authorizedColsByTable = mutableMapOf<OrganizationExternalDatabaseTable, Set<OrganizationExternalDatabaseColumn>>()
         edms.getExternalDatabaseTablesWithColumns(organizationId).forEach { (key, value) ->

--- a/src/main/kotlin/com/openlattice/organizations/DatasetController.kt
+++ b/src/main/kotlin/com/openlattice/organizations/DatasetController.kt
@@ -160,7 +160,6 @@ class DatasetController : DatasetApi, AuthorizingComponent {
         deleteExternalDatabaseTables(organizationId, setOf(tableName))
     }
 
-    //TODO change aclkeys to not have orgId
     @Timed
     @DeleteMapping(path = [ID_PATH + EXTERNAL_DATABASE_TABLE])
     override fun deleteExternalDatabaseTables(
@@ -168,7 +167,7 @@ class DatasetController : DatasetApi, AuthorizingComponent {
             @RequestBody tableNames: Set<String>) {
         val tableIdByFqn = getExternalDatabaseObjectIdByFqnMap(organizationId, tableNames)
         val tableIds = tableIdByFqn.values
-        val aclKeys = tableIds.map { AclKey(organizationId, it) }.toSet()
+        val aclKeys = tableIds.map { AclKey(it) }.toSet()
         aclKeys.forEach { aclKey ->
             ensureOwnerAccess(aclKey)
         }
@@ -176,7 +175,7 @@ class DatasetController : DatasetApi, AuthorizingComponent {
             ensureObjectCanBeDeleted(tableId)
             val columnIds = edms.getExternalDatabaseTableWithColumns(tableId).columns.map{ it.id }.toSet()
             columnIds.forEach { ensureObjectCanBeDeleted(it) }
-            val aclKeys = columnIds.map { AclKey(organizationId, tableId, it) }.toSet()
+            val aclKeys = columnIds.map { AclKey(tableId, it) }.toSet()
             aclKeys.forEach { aclKey ->
                 ensureOwnerAccess(aclKey)
             }


### PR DESCRIPTION
-Api for getting all tables/columns for an org now filters on READ permission instead of ensuring OWNER access.
-Delete table now checks for OWNER access on all columns before deleting the table