### PR TITLE
Feature/lattice 2416 tables as metadata columns as data

### DIFF
--- a/src/main/java/com/openlattice/datastore/permissions/controllers/PermissionsController.java
+++ b/src/main/java/com/openlattice/datastore/permissions/controllers/PermissionsController.java
@@ -27,15 +27,11 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.eventbus.EventBus;
 
-import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.core.IMap;
-import com.openlattice.assembler.PostgresDatabases;
 import com.openlattice.auditing.AuditEventType;
 import com.openlattice.auditing.AuditableEvent;
 import com.openlattice.auditing.AuditingComponent;
 import com.openlattice.auditing.AuditingManager;
 import com.openlattice.authorization.*;
-import com.openlattice.authorization.securable.SecurableObjectType;
 import com.openlattice.authorization.AccessCheck;
 import com.openlattice.authorization.Ace;
 import com.openlattice.authorization.Acl;
@@ -61,7 +57,6 @@ import java.time.OffsetDateTime;
 import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import javax.annotation.PostConstruct;
 
 import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
@@ -81,8 +76,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 @RestController
 @RequestMapping( PermissionsApi.CONTROLLER )
@@ -151,19 +144,19 @@ public class PermissionsController implements PermissionsApi, AuthorizingCompone
             switch ( action ) {
                 case ADD:
                     authorizations.addPermissions( acls );
-                    edms.executePrivilegesUpdate( action, getOrganizationExternalDatabaseAcls( acls ) );
+                    edms.executePrivilegesUpdate( action, getOrganizationExternalDbColumnAcls( acls ) );
                     recordEvents( createAuditableEvents( acls, AuditEventType.ADD_PERMISSION ) );
                     break;
 
                 case REMOVE:
                     authorizations.removePermissions( acls );
-                    edms.executePrivilegesUpdate( action, getOrganizationExternalDatabaseAcls( acls ) );
+                    edms.executePrivilegesUpdate( action, getOrganizationExternalDbColumnAcls( acls ) );
                     recordEvents( createAuditableEvents( acls, AuditEventType.REMOVE_PERMISSION ) );
                     break;
 
                 case SET:
                     authorizations.setPermissions( acls );
-                    edms.executePrivilegesUpdate( action, getOrganizationExternalDatabaseAcls( acls ) );
+                    edms.executePrivilegesUpdate( action, getOrganizationExternalDbColumnAcls( acls ) );
                     recordEvents( createAuditableEvents( acls, AuditEventType.SET_PERMISSION ) );
                     break;
 
@@ -268,10 +261,10 @@ public class PermissionsController implements PermissionsApi, AuthorizingCompone
         return auditingManager;
     }
 
-    private List<Acl> getOrganizationExternalDatabaseAcls( List<Acl> acls ) {
+    private List<Acl> getOrganizationExternalDbColumnAcls( List<Acl> acls ) {
         Set<AclKey> aclKeys = acls.stream().map( acl -> new AclKey( acl.getAclKey() ) ).collect( Collectors.toSet() );
         Set<AclKey> allOrgExternalDBAclKeys = securableObjectResolveTypeService
-                .getOrganizationExternalDatabaseAclKeys( aclKeys );
+                .getOrganizationExternalDbColumnAclKeys( aclKeys );
         return acls.stream().filter( acl -> allOrgExternalDBAclKeys.contains( acl.getAclKey() ) )
                 .collect( Collectors.toList() );
     }

--- a/src/main/kotlin/com/openlattice/organizations/DatasetController.kt
+++ b/src/main/kotlin/com/openlattice/organizations/DatasetController.kt
@@ -22,8 +22,9 @@ import java.util.*
 import java.util.stream.Collectors
 
 @SuppressFBWarnings(
-        value = ["BC_BAD_CAST_TO_ABSTRACT_COLLECTION"],
-        justification = "Allowing kotlin collection mapping cast to List")
+        value = ["RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE", "BC_BAD_CAST_TO_ABSTRACT_COLLECTION"],
+        justification = "Allowing redundant kotlin null check on lateinit variables, " +
+                "Allowing kotlin collection mapping cast to List")
 @RestController
 @RequestMapping(CONTROLLER)
 class DatasetController : DatasetApi, AuthorizingComponent {

--- a/src/main/kotlin/com/openlattice/organizations/DatasetController.kt
+++ b/src/main/kotlin/com/openlattice/organizations/DatasetController.kt
@@ -5,21 +5,15 @@ import com.google.common.base.Preconditions.checkState
 import com.google.common.net.InetAddresses
 import com.openlattice.authorization.*
 import com.openlattice.controllers.exceptions.ForbiddenException
+import com.openlattice.edm.requests.MetadataUpdate
 import com.openlattice.organization.*
-import com.openlattice.organization.OrganizationExternalDatabaseColumn
-import com.openlattice.organization.OrganizationExternalDatabaseTable
-import com.openlattice.organization.OrganizationExternalDatabaseTableColumnsPair
 import com.openlattice.postgres.PostgresConnectionType
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings
 import org.apache.olingo.commons.api.edm.FullQualifiedName
 import org.springframework.web.bind.annotation.*
-import javax.inject.Inject
-import org.springframework.web.bind.annotation.PathVariable
-import org.springframework.web.bind.annotation.PostMapping
-import com.openlattice.edm.requests.MetadataUpdate
-import org.springframework.web.bind.annotation.PatchMapping
 import java.util.*
 import java.util.stream.Collectors
+import javax.inject.Inject
 
 @SuppressFBWarnings(
         value = ["BC_BAD_CAST_TO_ABSTRACT_COLLECTION"],
@@ -170,6 +164,10 @@ class DatasetController : DatasetApi, AuthorizingComponent {
         edms.updateOrganizationExternalDatabaseTable(organizationId, tableFqnToId, metadataUpdate)
     }
 
+    @SuppressFBWarnings(
+            value = ["RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE"],
+            justification = "lateinit prevents NPE here"
+    )
     @Timed
     @PatchMapping(path = [ID_PATH + TABLE_NAME_PATH + COLUMN_NAME_PATH + EXTERNAL_DATABASE_COLUMN])
     override fun updateExternalDatabaseColumn(


### PR DESCRIPTION
This PR addresses the need to be able to view atlas table metadata without being able to see table data. We will now only grant postgres privileges on columns and not on entire tables. This will enable us to
-Use the OrgExternalDbTable object for permissioning table metadata
-Use the OrgExternalDbColumn object for permissioning table data on a column by column basis.

Here, the controller for `updateAcls()` will only pass columl-level permissions on for setting postgres privileges.