### PR TITLE
LATTICE 2423 Fix return type, filter for columns by permission, filter data returned by read permission

### DIFF
--- a/src/main/kotlin/com/openlattice/organizations/DatasetController.kt
+++ b/src/main/kotlin/com/openlattice/organizations/DatasetController.kt
@@ -130,7 +130,7 @@ class DatasetController : DatasetApi, AuthorizingComponent {
         val columns = edms.getExternalDatabaseTableWithColumns(tableId).columns
         val authorizedColumnIds = getAuthorizedColumnIds(tableId, columns.map { it.id }.toSet(), Permission.READ)
         if (authorizedColumnIds.isEmpty()) {
-            throw ForbiddenException("Missing required permissions to read table data.")
+            throw ForbiddenException("Unable to read data from table $tableId. Missing ${Permission.READ} permission on all columns.")
         }
         val authorizedColumns = columns.filter { it.id in authorizedColumnIds }.toSet()
         return edms.getExternalDatabaseTableData(organizationId, tableId, authorizedColumns, rowCount)

--- a/src/main/kotlin/com/openlattice/organizations/DatasetController.kt
+++ b/src/main/kotlin/com/openlattice/organizations/DatasetController.kt
@@ -129,6 +129,9 @@ class DatasetController : DatasetApi, AuthorizingComponent {
         ensureReadAccess(AclKey(tableId))
         val columns = edms.getExternalDatabaseTableWithColumns(tableId).columns
         val authorizedColumnIds = getAuthorizedColumnIds(tableId, columns.map { it.id }.toSet(), Permission.READ)
+        if (authorizedColumnIds.isEmpty()) {
+            throw ForbiddenException("Missing required permissions to read table data.")
+        }
         val authorizedColumns = columns.filter { it.id in authorizedColumnIds }.toSet()
         return edms.getExternalDatabaseTableData(organizationId, tableId, authorizedColumns, rowCount)
     }

--- a/src/main/kotlin/com/openlattice/organizations/DatasetController.kt
+++ b/src/main/kotlin/com/openlattice/organizations/DatasetController.kt
@@ -82,8 +82,8 @@ class DatasetController : DatasetApi, AuthorizingComponent {
     @Timed
     @GetMapping(path = [ID_PATH + EXTERNAL_DATABASE_TABLE + EXTERNAL_DATABASE_COLUMN])
     override fun getExternalDatabaseTablesWithColumns(
-            @PathVariable(ID) organizationId: UUID): Map<OrganizationExternalDatabaseTable, Set<OrganizationExternalDatabaseColumn>> {
-        ensureOwnerAccess(AclKey(organizationId))
+            @PathVariable(ID) organizationId: UUID): Set<OrganizationExternalDatabaseTableColumnsPair> {
+        //ensureOwnerAccess(AclKey(organizationId))
         return edms.getExternalDatabaseTablesWithColumns(organizationId)
     }
 

--- a/src/main/kotlin/com/openlattice/organizations/DatasetController.kt
+++ b/src/main/kotlin/com/openlattice/organizations/DatasetController.kt
@@ -259,7 +259,7 @@ class DatasetController : DatasetApi, AuthorizingComponent {
                 tableIds.map { AccessCheck(AclKey(it), EnumSet.of<Permission>(permission)) }.toSet(),
                 Principals.getCurrentPrincipals()
         )
-                .filter { it.permissions.contains(permission) }
+                .filter { it.permissions[permission]!! }
                 .map { it.aclKey[0] }.collect(Collectors.toSet())
     }
 
@@ -268,7 +268,7 @@ class DatasetController : DatasetApi, AuthorizingComponent {
                 columnIds.map { columnId -> AccessCheck(AclKey(tableId, columnId), EnumSet.of(permission)) }.toSet(),
                 Principals.getCurrentPrincipals()
         )
-                .filter { authz -> authz.permissions.contains(permission) }
+                .filter { authz -> authz.permissions[permission]!! }
                 .map { authz -> authz.aclKey[1] }.collect(Collectors.toSet())
     }
 


### PR DESCRIPTION
This PR
-Fixes the return type of the getTablesWithColumns controller
-Renames controller to clarify that returning columns returns only metadata on the columns and not any actual data
-Adds a controller to filter for returning columns that a user has a provided permission on
-Fixes controller for returning data so only data from columns with a read permission are returned