### PR TITLE
stop using the wrong commons calls

### DIFF
--- a/src/main/kotlin/com/openlattice/codex/controllers/CodexController.kt
+++ b/src/main/kotlin/com/openlattice/codex/controllers/CodexController.kt
@@ -20,7 +20,7 @@ import com.openlattice.twilio.TwilioConfiguration
 import com.twilio.rest.api.v2010.account.Message
 import com.twilio.security.RequestValidator
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings
-import org.apache.commons.lang.NotImplementedException
+import org.apache.commons.lang3.NotImplementedException
 import org.slf4j.LoggerFactory
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType

--- a/src/main/resources/log4j2.properties
+++ b/src/main/resources/log4j2.properties
@@ -26,9 +26,6 @@ property.rootDir = .
 property.runningDir = ${rootDir}/logging/
 property.rollingDir = ${rootDir}/logging/
 
-#filter.threshold.type = ThresholdFilter
-#filter.threshold.level = debug
-
 appenders = console, rolling
 
 appender.console.type = Console


### PR DESCRIPTION
This PR:
- stops using libraries pulled in transitively by c-c which are now absent